### PR TITLE
Fixing bug where .aws/config was being written to .aws/credentials file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Reload your profile by launching a new shell or running `source ~/.bash_profile`
 
 ### Switching profiles
 
-#### `awsx`
+#### `awsx` or `awsx [profile]`
 
 ### Adding a new profile
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,7 +66,7 @@ const deleteProfile = (profileName: string): void => {
   const awsConfig = getConfig(AWS_CONFIG_PATH);
 
   delete awsConfig[profileName];
-  writeConfig(AWS_CREDENTIALS_PATH, awsConfig);
+  writeConfig(AWS_CONFIG_PATH, awsConfig);
 
   const awsCredentials = getConfig(AWS_CREDENTIALS_PATH);
 


### PR DESCRIPTION
When removing a profile (used by remove-profile, enable-mfa and disable-mfa), contents of ~/.aws/config was being written to ~/.aws/credentials.