### PR TITLE
Move all dependencies to devDependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "eslint-config-neo/config-backend",
   "rules": {
-    "no-console": "off"
+    "no-console": "off",
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1 (January 26, 2020)
+
+Move all dependencies to devDependencies
+
 ## 1.0.0 (January 26, 2020)
 
 Initial release! :tada:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ alias awsx="source _awsx"
 
 Reload your profile by launching a new shell or running `source ~/.bash_profile`.
 
+### Upgrading
+
+```sh
+// npm
+npm install -g awsx
+
+// yarn
+yarn global upgrade awsx --latest
+```
+
 ### Switching profiles
 
 #### `awsx` or `awsx [profile]`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "awsx",
   "description": "AWS CLI profile switcher with MFA support",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
   "repository": {
@@ -44,13 +44,7 @@
       "prettier --write"
     ]
   },
-  "dependencies": {
-    "aws-sdk": "2.610.0",
-    "chalk": "3.0.0",
-    "ini": "1.3.5",
-    "inquirer": "7.0.4",
-    "yargs": "15.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/ini": "1.3.30",
     "@types/inquirer": "6.5.0",
@@ -58,15 +52,20 @@
     "@types/node": "13.5.0",
     "@types/yargs": "15.0.1",
     "@zeit/ncc": "0.21.0",
+    "aws-sdk": "2.610.0",
+    "chalk": "3.0.0",
     "eslint": "6.8.0",
     "eslint-config-neo": "0.5.2",
     "husky": "4.2.1",
+    "ini": "1.3.5",
+    "inquirer": "7.0.4",
     "jest": "^25.1.0",
     "lint-staged": "10.0.2",
     "prettier": "1.19.1",
     "rimraf": "3.0.0",
     "ts-jest": "^25.0.0",
     "ts-node": "8.6.2",
-    "typescript": "3.7.5"
+    "typescript": "3.7.5",
+    "yargs": "15.1.0"
   }
 }


### PR DESCRIPTION
Since we are compiling with `ncc` all of our dependencies are included in the compiled app and we have no runtime dependencies. Removing them speeds up installation of the app.