### PR TITLE
Adding commands for assumed role account switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ build
 dist
 node_modules
 
+.idea
+
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.0 (March 30, 2020)
+## 1.1.0 (April 2, 2020)
 
 Adding and augmenting commands to enable assumed role adoption
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0 (March 30, 2020)
+
+Adding and augmenting commands to enable assumed role adoption
+
 ## 1.0.1 (January 26, 2020)
 
 Move all dependencies to devDependencies

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ yarn global upgrade awsx --latest
 
 ### Switching profiles
 
-#### `awsx` or `awsx [profile]`
+#### `awsx` or `awsx [profile]` or `awsx [profile] [assume-role-profile]`
 
-If you don't specify a profile name you will be prompted to choose from one of your existing profiles. If the selected profile has MFA enabled and you want to force a new MFA login use the `--force-mfa` flag.
+If you don't specify a profile name (or an assume role profile name, if applicable) you will be prompted to choose from one of your existing profiles. If the selected profile has MFA enabled and you want to force a new MFA login use the `--force-mfa` flag.
 
 ### Adding a new profile
 
@@ -65,6 +65,14 @@ If you don't have MFA set up on your AWS account you can enable it by following 
 ### Removing a profile
 
 #### `awsx remove-profile [profile]`
+
+### Adding an assume role profile
+
+#### `awsx add-assume-role-profile [profile] [parent-profile] [role-arn] [default-region] [output-format]`
+
+### Removing an assume role profile
+
+#### `awsx remove-assume-role-profile [profile]`
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "awsx",
   "description": "AWS CLI profile switcher with MFA support",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
   "repository": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -125,15 +125,13 @@ const switchProfile = async (
         assumeRoleProfileName
       );
 
-      if (name) {
-        console.log(
-          chalk.green(
-            `Switched to profile ${selectedProfile.profileName}${
-              activeProfile ? ` -> ${activeProfile}` : ''
-            }`
-          )
-        );
-      }
+      console.log(
+        chalk.green(
+          `Switched to profile ${selectedProfile.profileName}${
+            activeProfile ? ` -> ${activeProfile}` : ''
+          }`
+        )
+      );
 
       return;
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,8 +25,6 @@ import getTemporaryCredentials, {
 import exportEnvironmentVariables from './exporter';
 import pkg from '../package.json';
 
-updateNotifier({ pkg }).notify();
-
 const profiles = getProfileNames();
 let currentProfile = process.env.AWS_PROFILE || '';
 
@@ -596,6 +594,8 @@ const disableMfa = async (name?: string): Promise<void> => {
 };
 
 const awsx = (): void => {
+  updateNotifier({ pkg }).notify();
+
   yargs
     .scriptName('awsx')
     .usage('$0 [command]')

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,7 +57,7 @@ const switchAssumeRoleProfile = async (
       console.error(chalk.red(`No profile '${assumeRoleProfileName}' found.`));
     }
   } else if (assumeRoleProfiles.length > 0) {
-    const rootProfileOption = 'Remain on root profile';
+    const rootProfileOption = 'root profile';
 
     const answers = await inquirer.prompt([
       {

--- a/src/app.ts
+++ b/src/app.ts
@@ -40,7 +40,7 @@ const validateMfaExpiry = (mfaExpiry: number): boolean | string => {
   }
 };
 
-const switchToAssumeRoleProfile = async (
+const switchAssumeRoleProfile = async (
   parentProfileName: string,
   assumeRoleProfileName?: string
 ): Promise<string | undefined> => {
@@ -120,7 +120,7 @@ const switchProfile = async (
     if (!forceMFA && lastCredentials && selectedProfile.mfaSessionValid) {
       exportEnvironmentVariables(selectedProfile.profileName);
 
-      const activeProfile = await switchToAssumeRoleProfile(
+      const activeProfile = await switchAssumeRoleProfile(
         selectedProfile.profileName,
         assumeRoleProfileName
       );
@@ -157,7 +157,7 @@ const switchProfile = async (
     exportEnvironmentVariables(selectedProfile.profileName);
   }
 
-  const activeProfile = await switchToAssumeRoleProfile(
+  const activeProfile = await switchAssumeRoleProfile(
     selectedProfile.profileName,
     assumeRoleProfileName
   );
@@ -363,9 +363,9 @@ const addAssumeRoleProfile = async (
     const assumeRoleProfile: AssumeRoleProfileConfiguration = {
       profileName: name,
       parentProfileName: parentProfile,
-      roleArn,
-      defaultRegion,
-      outputFormat
+      awsRoleArn: roleArn,
+      awsDefaultRegion: defaultRegion,
+      awsOutputFormat: outputFormat
     };
 
     createAssumeRoleProfile(assumeRoleProfile);
@@ -377,9 +377,10 @@ const addAssumeRoleProfile = async (
         message: 'Name'
       },
       {
-        type: 'input',
+        type: 'list',
         name: 'parentProfile',
-        message: 'Parent Profile Name'
+        message: 'Choose a parent profile',
+        choices: profiles
       },
       {
         type: 'input',
@@ -403,9 +404,9 @@ const addAssumeRoleProfile = async (
     const profile: AssumeRoleProfileConfiguration = {
       profileName: profileAnswers.profile,
       parentProfileName: profileAnswers.parentProfile,
-      roleArn: profileAnswers.roleArn,
-      defaultRegion: profileAnswers.defaultRegion,
-      outputFormat: profileAnswers.outputFormat
+      awsRoleArn: profileAnswers.roleArn,
+      awsDefaultRegion: profileAnswers.defaultRegion,
+      awsOutputFormat: profileAnswers.outputFormat
     };
 
     createAssumeRoleProfile(profile);

--- a/src/app.ts
+++ b/src/app.ts
@@ -580,7 +580,7 @@ const awsx = (): void => {
     .scriptName('awsx')
     .usage('$0 [command]')
     .command({
-      command: '$0 [profile] [assumeRoleProfile]',
+      command: '$0 [profile] [assume-role-profile]',
       describe: 'Switch profiles',
       builder: (
         yargs
@@ -590,7 +590,7 @@ const awsx = (): void => {
             describe: 'The name of the profile to switch to',
             type: 'string'
           })
-          .positional('assumeRoleProfile', {
+          .positional('assume-role-profile', {
             describe: 'The name of the assumed role profile to switch to',
             type: 'string'
           })
@@ -685,6 +685,26 @@ const awsx = (): void => {
       }
     })
     .command({
+      command: 'remove-profile [profile]',
+      describe: 'Remove profile',
+      builder: (
+        yargs
+      ): Argv<{
+        profile?: string;
+      }> =>
+        yargs.positional('profile', {
+          type: 'string',
+          describe: 'The name of the profile to delete'
+        }),
+      handler: async (args: { profile?: string }): Promise<void> => {
+        try {
+          await removeProfile(args.profile);
+        } catch (error) {
+          console.error(chalk.red(error.message));
+        }
+      }
+    })
+    .command({
       command:
         'add-assume-role-profile [profile] [parent-profile] [role-arn] [default-region] [output-format]',
       describe: 'Add assume role profile',
@@ -735,26 +755,6 @@ const awsx = (): void => {
             args.defaultRegion,
             args.outputFormat
           );
-        } catch (error) {
-          console.error(chalk.red(error.message));
-        }
-      }
-    })
-    .command({
-      command: 'remove-profile [profile]',
-      describe: 'Remove profile',
-      builder: (
-        yargs
-      ): Argv<{
-        profile?: string;
-      }> =>
-        yargs.positional('profile', {
-          type: 'string',
-          describe: 'The name of the profile to delete'
-        }),
-      handler: async (args: { profile?: string }): Promise<void> => {
-        try {
-          await removeProfile(args.profile);
         } catch (error) {
           console.error(chalk.red(error.message));
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -197,7 +197,7 @@ const getAssumeRoleProfiles = (parentProfile?: string): AssumeRoleProfileConfigu
 
   const profiles: AssumeRoleProfileConfiguration[] = [];
 
-  for (const profile in awsConfig) {
+  for (const profile of Object.keys(awsConfig)) {
     if (awsConfig[profile] && awsConfig[profile].role_arn) {
       profiles.push({
         profileName: profile,

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,30 +94,6 @@ const getProfiles = (): ProfileConfiguration[] => {
   return profiles;
 };
 
-const getAssumeRoleProfiles = (parentProfile?: string): AssumeRoleProfileConfiguration[] => {
-  const awsConfig = getConfig(AWS_CONFIG_PATH);
-
-  const profiles: AssumeRoleProfileConfiguration[] = [];
-
-  for (const profile in awsConfig) {
-    if (awsConfig[profile] && awsConfig[profile].role_arn) {
-      profiles.push({
-        profileName: profile,
-        parentProfileName: awsConfig[profile].source_profile,
-        roleArn: awsConfig[profile].role_arn,
-        defaultRegion: awsConfig[profile].region,
-        outputFormat: awsConfig[profile].output
-      });
-    }
-  }
-
-  if (parentProfile) {
-    return profiles.filter(profile => profile.parentProfileName === parentProfile);
-  } else {
-    return profiles;
-  }
-};
-
 const getProfileNames = (): string[] => {
   return getProfiles().map(profile => profile.profileName);
 };
@@ -216,6 +192,34 @@ const deleteProfile = (profileName: string): void => {
   writeConfig(AWS_CREDENTIALS_PATH, awsCredentials);
 };
 
+const getAssumeRoleProfiles = (parentProfile?: string): AssumeRoleProfileConfiguration[] => {
+  const awsConfig = getConfig(AWS_CONFIG_PATH);
+
+  const profiles: AssumeRoleProfileConfiguration[] = [];
+
+  for (const profile in awsConfig) {
+    if (awsConfig[profile] && awsConfig[profile].role_arn) {
+      profiles.push({
+        profileName: profile,
+        parentProfileName: awsConfig[profile].source_profile,
+        roleArn: awsConfig[profile].role_arn,
+        defaultRegion: awsConfig[profile].region,
+        outputFormat: awsConfig[profile].output
+      });
+    }
+  }
+
+  if (parentProfile) {
+    return profiles.filter(profile => profile.parentProfileName === parentProfile);
+  } else {
+    return profiles;
+  }
+};
+
+const getAssumeRoleProfile = (profileName: string): AssumeRoleProfileConfiguration | undefined => {
+  return getAssumeRoleProfiles().find(profile => profile.profileName === `profile ${profileName}`);
+};
+
 const createAssumeRoleProfile = (profile: AssumeRoleProfileConfiguration): void => {
   const awsConfig = getConfig(AWS_CONFIG_PATH);
 
@@ -229,16 +233,25 @@ const createAssumeRoleProfile = (profile: AssumeRoleProfileConfiguration): void 
   writeConfig(AWS_CONFIG_PATH, awsConfig);
 };
 
+const deleteAssumeRoleProfile = (profileName: string): void => {
+  const awsConfig = getConfig(AWS_CONFIG_PATH);
+
+  delete awsConfig[`profile ${profileName}`];
+  writeConfig(AWS_CONFIG_PATH, awsConfig);
+};
+
 export {
   backupConfig,
   initConfig,
   isMfaSessionStillValid,
   getProfileNames,
   getProfile,
-  getAssumeRoleProfiles,
   getCredentials,
   writeTemporaryCredentials,
   createProfile,
   deleteProfile,
-  createAssumeRoleProfile
+  getAssumeRoleProfiles,
+  getAssumeRoleProfile,
+  createAssumeRoleProfile,
+  deleteAssumeRoleProfile
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -202,9 +202,9 @@ const getAssumeRoleProfiles = (parentProfile?: string): AssumeRoleProfileConfigu
       profiles.push({
         profileName: profile,
         parentProfileName: awsConfig[profile].source_profile,
-        roleArn: awsConfig[profile].role_arn,
-        defaultRegion: awsConfig[profile].region,
-        outputFormat: awsConfig[profile].output
+        awsRoleArn: awsConfig[profile].role_arn,
+        awsDefaultRegion: awsConfig[profile].region,
+        awsOutputFormat: awsConfig[profile].output
       });
     }
   }
@@ -224,10 +224,10 @@ const createAssumeRoleProfile = (profile: AssumeRoleProfileConfiguration): void 
   const awsConfig = getConfig(AWS_CONFIG_PATH);
 
   awsConfig[`profile ${profile.profileName}`] = {
-    role_arn: profile.roleArn,
+    role_arn: profile.awsRoleArn,
     source_profile: profile.parentProfileName,
-    region: profile.defaultRegion,
-    output: profile.outputFormat
+    region: profile.awsDefaultRegion,
+    output: profile.awsOutputFormat
   };
 
   writeConfig(AWS_CONFIG_PATH, awsConfig);

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -4,31 +4,8 @@ import { AWSX_HOME } from './config';
 
 const EXPORTS_PATH = `${AWSX_HOME}/exports.sh`;
 
-const exportEnvironmentVariables = (
-  profile: string,
-  accessKey: string,
-  secretKey: string,
-  defaultRegion?: string,
-  outputFormat?: string,
-  sessionToken?: string
-): void => {
-  let exportScript = `export AWS_PROFILE=${profile} AWS_ACCESS_KEY_ID=${accessKey} AWS_SECRET_ACCESS_KEY=${secretKey}`;
-
-  if (defaultRegion) {
-    exportScript += ` AWS_DEFAULT_REGION=${defaultRegion}`;
-  }
-
-  if (sessionToken) {
-    exportScript += ` AWS_SESSION_TOKEN=${sessionToken}`;
-  } else {
-    exportScript += ` AWS_SESSION_TOKEN=""`;
-  }
-
-  if (outputFormat) {
-    exportScript += ` AWS_DEFAULT_OUTPUT=${outputFormat}`;
-  }
-
-  fs.writeFileSync(EXPORTS_PATH, exportScript);
+const exportEnvironmentVariables = (profile: string): void => {
+  fs.writeFileSync(EXPORTS_PATH, `export AWS_PROFILE=${profile}`);
 };
 
 export default exportEnvironmentVariables;

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -5,7 +5,7 @@ import { AWSX_HOME } from './config';
 const EXPORTS_PATH = `${AWSX_HOME}/exports.sh`;
 
 const exportEnvironmentVariables = (profile: string): void => {
-  fs.writeFileSync(EXPORTS_PATH, `export AWS_PROFILE=${profile}`);
+  fs.writeFileSync(EXPORTS_PATH, `export AWS_PROFILE="${profile}"`);
 };
 
 export default exportEnvironmentVariables;

--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -5,7 +5,7 @@ import { AWSX_HOME } from './config';
 const EXPORTS_PATH = `${AWSX_HOME}/exports.sh`;
 
 const exportEnvironmentVariables = (profile: string): void => {
-  fs.writeFileSync(EXPORTS_PATH, `export AWS_PROFILE="${profile}"`);
+  fs.writeFileSync(EXPORTS_PATH, `export AWS_PROFILE="${profile}" AWS_SDK_LOAD_CONFIG="true"`);
 };
 
 export default exportEnvironmentVariables;

--- a/src/mfa-login.ts
+++ b/src/mfa-login.ts
@@ -17,9 +17,9 @@ export interface ProfileConfiguration {
 export interface AssumeRoleProfileConfiguration {
   profileName: string;
   parentProfileName: string;
-  roleArn: string;
-  defaultRegion: string;
-  outputFormat: string;
+  awsRoleArn: string;
+  awsDefaultRegion: string;
+  awsOutputFormat: string;
 }
 
 export interface AWSCredentials {

--- a/src/mfa-login.ts
+++ b/src/mfa-login.ts
@@ -14,6 +14,14 @@ export interface ProfileConfiguration {
   mfaSessionValid?: boolean;
 }
 
+export interface AssumeRoleProfileConfiguration {
+  profileName: string;
+  parentProfileName: string;
+  roleArn: string;
+  defaultRegion: string;
+  outputFormat: string;
+}
+
 export interface AWSCredentials {
   profileName: string;
   awsAccessKeyId: string;


### PR DESCRIPTION
https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html

Enabling the ability to jump to "sub" profile from an initial parent profile. 