### PR TITLE
Move update notifier to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1 (April 14, 2020)
+
+Move `update-notifier` to dependencies and exclude from ncc build
+
 ## 1.1.0 (April 2, 2020)
 
 Adding and augmenting commands to enable assumed role adoption

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "awsx",
   "description": "AWS CLI profile switcher with MFA support",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
   "repository": {
@@ -18,8 +18,8 @@
   "scripts": {
     "start": "NODE_ENV=development ts-node src/app.ts",
     "start:build": "node bin/awsx.js",
-    "build": "NODE_ENV=production ncc build src/app.ts -o build --minify",
-    "watch": "NODE_ENV=production ncc build src/app.ts -o build --minify --watch",
+    "build": "NODE_ENV=production ncc build src/app.ts -o build --minify --external update-notifier",
+    "watch": "NODE_ENV=production ncc build src/app.ts -o build --watch --external update-notifier",
     "test": "NODE_ENV=test jest",
     "clean": "rimraf build",
     "lint": "eslint \"**/*.{ts,js}\"",
@@ -44,13 +44,15 @@
       "prettier --write"
     ]
   },
-  "dependencies": {},
+  "dependencies": {
+    "update-notifier": "4.1.0"
+  },
   "devDependencies": {
     "@types/ini": "1.3.30",
     "@types/inquirer": "6.5.0",
-    "@types/jest": "^24.9.1",
+    "@types/jest": "24.9.1",
     "@types/node": "13.5.0",
-    "@types/update-notifier": "^2.5.0",
+    "@types/update-notifier": "2.5.0",
     "@types/yargs": "15.0.1",
     "@zeit/ncc": "0.21.0",
     "aws-sdk": "2.610.0",
@@ -67,7 +69,6 @@
     "ts-jest": "^25.0.0",
     "ts-node": "8.6.2",
     "typescript": "3.7.5",
-    "update-notifier": "^4.1.0",
     "yargs": "15.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,7 +443,7 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^24.9.1":
+"@types/jest@24.9.1":
   version "24.9.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
   integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
@@ -482,7 +482,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/update-notifier@^2.5.0":
+"@types/update-notifier@2.5.0":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@types/update-notifier/-/update-notifier-2.5.0.tgz#63cfcee92cc915f9a6eea4d1442ec6efd012e118"
   integrity sha512-YV+ZcSIiv30GhLM7WwxI+bsbcW34d3Yhl2JSFBNFL6qtfsoI9++hogxz+jTqeS86ynKcMUE0AsnLWQynfJnsfA==
@@ -5072,7 +5072,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-update-notifier@^4.1.0:
+update-notifier@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-4.1.0.tgz#4866b98c3bc5b5473c020b1250583628f9a328f3"
   integrity sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==


### PR DESCRIPTION
`update-notifier` can't be properly bundled by ncc so it needs to be a regular dependency.