### PR TITLE
Set the root profile option's value to the name of the profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # awsx changelog
 
+## 1.4.1 (April 4, 2022)
+
+- Fixing the value of the `root profile` option to correspond with the name of the profile.
+
 ## 1.4.0 (January 4, 2022)
 
 - Warn users when secret key X days old

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "awsx",
   "description": "AWS CLI profile switcher with MFA support",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
   "repository": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -61,7 +61,7 @@ const switchAssumeRoleProfile = async (
       console.error(chalk.red(`No profile '${assumeRoleProfileName}' found.`));
     }
   } else if (assumeRoleProfiles.length > 0) {
-    const rootProfileOption = { title: 'root profile', value: 'root profile' };
+    const rootProfileOption = { title: 'root profile', value: parentProfileName };
     const choices = [
       rootProfileOption,
       ...assumeRoleProfiles.map((profile) => ({ title: profile, value: profile })),


### PR DESCRIPTION
Fixes an issue where the AWS_PROFILE environment variable would be exported as 'root profile', rather than the name of the profile itself.