### PR TITLE
Fix Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # awsx changelog
 
-## 1.4.2 (May 4, 2022)
+## 1.4.2 (May 10, 2022)
 
-- Fixing [mfaArn] validation
+- Fixing `mfaArn` validation
 - Fixing `whoami` command
 - Fixing trailing spaces and verify user credentials
+- Add `onCancel` callback on user cancels/exit
 
 ## 1.4.1 (April 4, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # awsx changelog
 
+## 1.4.2 (May 4, 2022)
+
+- Fixing [mfaArn] validation
+- Fixing `whoami` command
+- Fixing trailing spaces and verify user credentials
+
 ## 1.4.1 (April 4, 2022)
 
 - Fixing the value of the `root profile` option to correspond with the name of the profile.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "awsx",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "awsx",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "update-notifier": "^4.1.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "awsx",
   "description": "AWS CLI profile switcher with MFA support",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
   "repository": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,7 @@ import prompts from 'prompts';
 import yargs, { Argv } from 'yargs';
 import updateNotifier from 'update-notifier';
 
-import { onCancel } from './lib/prompts-helper';
+import { onCancel } from './lib/prompts';
 
 import {
   configFileCheck,
@@ -79,7 +79,7 @@ const switchAssumeRoleProfile = async (
           (choice) => choice.value === currentProfile || choice.value === assumeRoleProfiles[0]
         ),
       },
-      { onCancel: () => onCancel('Aborting [choose-assume-role] profile') }
+      { onCancel: () => onCancel() }
     );
 
     if (answers.profile !== rootProfileOption) {
@@ -258,7 +258,7 @@ const addProfile = async (
           message: 'Use MFA',
         },
       ],
-      { onCancel: () => onCancel('Aborting [add-profile]') }
+      { onCancel: () => onCancel('Cancelling add profile') }
     );
 
     await verifyAndGetCallerIdentity({
@@ -294,7 +294,7 @@ const addProfile = async (
             validate: validateMfaExpiry,
           },
         ],
-        { onCancel: () => onCancel('Aborting [add-profile]') }
+        { onCancel: () => onCancel('Cancelling add profile') }
       );
 
       profile.mfaDeviceArn = mfaAnswers.mfaArn;
@@ -321,7 +321,7 @@ const removeProfile = async (name?: string): Promise<void> => {
         choices: choices,
         initial: choices.findIndex((choice) => choice.value === currentProfile),
       },
-      { onCancel: () => onCancel('Aborting [remove-profile]') }
+      { onCancel: () => onCancel('Cancelling remove profile') }
     );
 
     profileName = answers.profile;
@@ -373,7 +373,7 @@ const removeAssumeRoleProfile = async (name?: string): Promise<void> => {
             choice.value === assumeRoleProfiles[0].profileName.replace('profile ', '')
         ),
       },
-      { onCancel: () => onCancel('Aborting [remove-assume-profile]') }
+      { onCancel: () => onCancel('Canceling remove assume profile') }
     );
 
     profileName = answers.profile;
@@ -506,7 +506,7 @@ const enableMfa = async (name?: string): Promise<void> => {
           (choice) => choice.value === currentProfile || choice.value === profiles[0]
         ),
       },
-      { onCancel: () => onCancel('Aborting [enable-mfa]') }
+      { onCancel: () => onCancel() }
     );
 
     profileName = answers.profile;
@@ -650,7 +650,7 @@ const disableMfa = async (name?: string): Promise<void> => {
         initial: selectedProfile.awsOutputFormat,
       },
     ],
-    { onCancel: () => onCancel('Aborting [disable-mfa]') }
+    { onCancel: () => onCancel() }
   );
 
   deleteProfile(profileName);

--- a/src/app.ts
+++ b/src/app.ts
@@ -373,7 +373,7 @@ const removeAssumeRoleProfile = async (name?: string): Promise<void> => {
             choice.value === assumeRoleProfiles[0].profileName.replace('profile ', '')
         ),
       },
-      { onCancel: () => onCancel('Canceling remove assume profile') }
+      { onCancel: () => onCancel('Cancelling remove assume profile') }
     );
 
     profileName = answers.profile;

--- a/src/command/whoami.ts
+++ b/src/command/whoami.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
-import { STS } from '@aws-sdk/client-sts';
+// import { STS } from '@aws-sdk/client-sts';
 import { IAM } from '@aws-sdk/client-iam';
 
-import { getCurrentProfile } from '../lib/profile';
+import { getCurrentProfile, verifyAndGetCallerIdentity } from '../lib/profile';
 import { getAssumeRoleProfile } from '../config';
-import { timeout } from '../lib/time';
+// import { timeout } from '../lib/time';
 
 const assumedRole = (arn?: string): string | undefined => {
   return arn ? arn.split('/')[1] : undefined;
@@ -20,10 +20,12 @@ const whoami = async (): Promise<void> => {
     return;
   }
 
-  const sts = new STS({});
   const iam = new IAM({});
 
-  const identity = await Promise.race([sts.getCallerIdentity({}), timeout(1500)]);
+  const identity = await verifyAndGetCallerIdentity();
+
+  console.log('Identity');
+  console.log(identity);
 
   if (!identity) {
     console.log(chalk.red(`Session is expired or invalid`));

--- a/src/command/whoami.ts
+++ b/src/command/whoami.ts
@@ -1,10 +1,8 @@
 import chalk from 'chalk';
-// import { STS } from '@aws-sdk/client-sts';
 import { IAM } from '@aws-sdk/client-iam';
 
 import { getCurrentProfile, verifyAndGetCallerIdentity } from '../lib/profile';
 import { getAssumeRoleProfile } from '../config';
-// import { timeout } from '../lib/time';
 
 const assumedRole = (arn?: string): string | undefined => {
   return arn ? arn.split('/')[1] : undefined;

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,5 +1,36 @@
+import { STS, Credentials, GetCallerIdentityCommandOutput } from '@aws-sdk/client-sts';
+
+import { timeout } from './time';
+
 const getCurrentProfile = (): string => {
   return process.env.AWS_PROFILE || '';
 };
 
-export { getCurrentProfile };
+const verifyAndGetCallerIdentity = async (
+  credentials?: Partial<Credentials>
+): Promise<GetCallerIdentityCommandOutput | void> => {
+  let sts: STS;
+
+  if (credentials) {
+    console.log('Using custom credentials');
+    console.log(credentials);
+    sts = new STS({
+      credentials: {
+        accessKeyId: credentials.AccessKeyId ?? '',
+        secretAccessKey: credentials.SecretAccessKey ?? '',
+      },
+    });
+  } else {
+    sts = new STS({});
+  }
+
+  try {
+    const identity = await Promise.race([sts.getCallerIdentity({}), timeout(1500)]);
+
+    return identity;
+  } catch (error) {
+    throw new Error(`Invalid credentials [AccessKey] or [SecretKey]\n ${error}`);
+  }
+};
+
+export { getCurrentProfile, verifyAndGetCallerIdentity };

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -27,7 +27,7 @@ const verifyAndGetCallerIdentity = async (
 
     return identity;
   } catch (error) {
-    throw new Error(`Invalid credentials [AccessKey] or [SecretKey]\n ${error}`);
+    throw new Error(`Invalid credentials AccessKey or SecretKey\n ${error}`);
   }
 };
 

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -12,8 +12,6 @@ const verifyAndGetCallerIdentity = async (
   let sts: STS;
 
   if (credentials) {
-    console.log('Using custom credentials');
-    console.log(credentials);
     sts = new STS({
       credentials: {
         accessKeyId: credentials.AccessKeyId ?? '',

--- a/src/lib/prompts-helper.ts
+++ b/src/lib/prompts-helper.ts
@@ -1,9 +1,0 @@
-import chalk from 'chalk';
-
-const onCancel = (text: string): void => {
-  console.log(chalk.red(text));
-
-  return process.exit(1);
-};
-
-export { onCancel };

--- a/src/lib/prompts-helper.ts
+++ b/src/lib/prompts-helper.ts
@@ -1,0 +1,9 @@
+import chalk from 'chalk';
+
+const onCancel = (text: string): void => {
+  console.log(chalk.red(text));
+
+  return process.exit(1);
+};
+
+export { onCancel };

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,0 +1,12 @@
+import chalk from 'chalk';
+
+const onCancel = (text?: string): void => {
+
+  if (text) {
+    console.log(chalk.yellow(`⚠ ${text}`));
+  }
+
+  return process.exit(1);
+};
+
+export { onCancel };


### PR DESCRIPTION
Fixing errors:
1) `whoami` command, 
```
const profile = getProfile(getCurrentProfile());
```
was always returning undefined, since we tried to get [profile] with assume role.
![image](https://user-images.githubusercontent.com/61769420/166817154-cbfb1339-7be7-4876-b5b0-f3f26cb92795.png)

2) When using `add-profile` command, if user passes [accessKey] or [secretKey] that have spaces before or after, **ini** inserted other characters and the profile had unacceptable credentials.
Additionally added identity validation during `add-profile` command, in case credentials have another type of error except for spaces.

3) Added validation to [mfaDeviceArn] , otherwise it was accepting an empty string

4) Fix abort `prompts`, when user aborts `[add-profile]` or `[switch-assume-role]` , the partial information is saved to the **profile** or **export.sh** files.